### PR TITLE
Strip illegal control characters

### DIFF
--- a/lib/xlsxtream/xml.rb
+++ b/lib/xlsxtream/xml.rb
@@ -11,8 +11,9 @@ module Xlsxtream
 
     WS_AROUND_TAGS = /(?<=>)\s+|\s+(?=<)/.freeze
 
-    UNSAFE_ATTR_CHARS = /[&"<>]/.freeze
-    UNSAFE_VALUE_CHARS = /[&<>]/.freeze
+    ILLEGAL_CONTROL_CHARACTERS = "\x00-\x08\x11-\x12\x0e-\x1f"
+    UNSAFE_ATTR_CHARS = /[&"<>#{ILLEGAL_CONTROL_CHARACTERS}]/.freeze
+    UNSAFE_VALUE_CHARS = /[&<>#{ILLEGAL_CONTROL_CHARACTERS}]/.freeze
 
     class << self
 


### PR DESCRIPTION
These characters are not allowed in XML 1.0 files (and strongly discouraged in XML 1.1 files; but xlsxtream generates 1.0 files).